### PR TITLE
Added currently playing check to end game voting

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -1176,6 +1176,10 @@ logger.info("msg: "+msg);
                     return;
                 }
             }
+            if(!playerManagement.playerIsPlaying(kagName){
+                bot.say(to, from+:": you are not currently in game and cannot vote to end the game")
+                return;
+            }
             playerManagement.endVotes.push(kagName);
             if(playerManagement.endVotes.length>=endVotesRequired){
                 bot.say(to, "Forced end on server " + playerManagement.playingServer);


### PR DESCRIPTION
The endvote code currently allows anyone in the gather chat to put forward an end vote, leading to the possible situation of non-playing users forcing a game to end without the participants consent. With this added playerIsPlaying check only players currently in game can vote to end the game.